### PR TITLE
Make passing in jade optional.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
-
 module.exports = function (jade) {
+    if (typeof jade === 'undefined') {
+        jade = require('jade');
+    }
     require('./lib/filters')(jade);
     require('./lib/compiler')(jade);
 };


### PR DESCRIPTION
This shouldn't required, and causes issues in some use cases.

See monokrome/jaded-brunch#5 for an example.
