### PR TITLE
Update jade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jade-php",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "jade compiler and filter for PHP",
   "main": "index.js",
   "scripts": {
@@ -22,6 +22,6 @@
   },
   "dependencies": {
     "constantinople": "^3.0.1",
-    "jade": "~0.35.0"
+    "jade": "^1.7.0"
   }
 }


### PR DESCRIPTION
After last changes this library obsolete classes and other attributes (other than php). Update jade version fix constantinople warning and dissapearing attributes issue. All tests passed ok.
